### PR TITLE
Include closed projects in projects list

### DIFF
--- a/src/octokit/ProjectsOctoKit.ts
+++ b/src/octokit/ProjectsOctoKit.ts
@@ -54,6 +54,7 @@ export class ProjectsOctoKit extends OctoKitBase {
       accept: 'application/vnd.github.inertia-preview+json',
       owner: repo.owner,
       repo: repo.repo,
+      state: 'all',
       per_page: 100,
     });
 


### PR DESCRIPTION
This is to support memex migrations. As we migrate we will mark old boards as closed, but want them to still be tracked by the bot